### PR TITLE
Sets up context on graphql server for prisma client

### DIFF
--- a/server/graphqlServer.js
+++ b/server/graphqlServer.js
@@ -1,11 +1,13 @@
 const express = require('express');
 const { graphqlHTTP } = require('express-graphql');
 const schema = require('./models/graphqlSchema');
+const { context } = require('./models/context');
 
 app = express();
 app.use('/graphql', graphqlHTTP({
   schema: schema,
   graphiql: true,
+  context: context,
 }));
 
 app.listen(4000);

--- a/server/models/context.js
+++ b/server/models/context.js
@@ -1,0 +1,11 @@
+const { PrismaClient } = require('@prisma/client');
+
+const prisma = new PrismaClient();
+
+const context = {
+  prisma: prisma,
+};
+
+module.exports = {
+  context: context,
+};


### PR DESCRIPTION
- Sets up context which can be used as an argument in resolvers. To access the prisma client